### PR TITLE
Made tags commaless

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ To be updated.
 
 ## Updates
 05/12/2023: support for Zotero tags and extra fields
+
 05/03/2023: callouts are now the color of the corresponding Zotero highlights

--- a/infoheader.md
+++ b/infoheader.md
@@ -1,3 +1,11 @@
+---
+
+tags: 
+{%- for tag in tags %}
+- {{tag.tag}}
+{%- endfor %}
+
+---
 ```ad-note
 title: Citation
 {{bibliography}}
@@ -31,7 +39,12 @@ title: Metadata
 {% if pages %} **Pages**:: {{pages}}  {% endif %}
 {% if DOI %}**DOI**:: {{DOI}}  {% endif %}
 {% if ISBN %}**ISBN**:: {{ISBN}}  {% endif %}
-{% if hashTags %}**Tags**:: {{hashTags}} {% endif %}
+
+{% if hashTags %}
+**Tags**:: {% for tag in tags -%}
+#{{tag.tag}} {% endfor -%}
+{% endif %}
+
 {{extra}}
 ```
 


### PR DESCRIPTION
Changes to infoheader.md
- now using the {{tags}} field to import into the metadata callout w/o comma separators #5
- also added tags to the YAML front matter b/c Obsidian was not properly searching for tags within the callouts. This allows pages to be properly indexed & searched when clicking tags

Formatting changes to README.md